### PR TITLE
Fix Severin entry

### DIFF
--- a/_posts/2017-09-10-severin.markdown
+++ b/_posts/2017-09-10-severin.markdown
@@ -51,13 +51,11 @@ tags: [medium, humanoid, cr11, tyranny-of-dragons]
 
 **Legendary Actions**
 
-The severin can take 3 legendary actions, choosing from the options below. Only one legendary action option can be used at a time, and only at the end of another creature's turn. The severin regains spent legendary actions at the start of its turn.
+If Severin is wearing the Mask of the Dragon Queen, he can take 3 legendary actions, choosing from the options listed. Only one legendary action option can be used at a time and only at the end of another creature's turn. Severin regains spent legendary actions at the start of his turn.
 
-***Attack.*** If Severin is wearing the Mask of the Dragon Queen, he can take 3 legendary actions, choosing from the options listed. Only one legendary action option can be used at a time and only at the end of another creature's turn. Severin regains spent legendary actions at the start of his turn.
+***Attack.*** Severin makes one attack.
 
-Severin makes one attack.
-
-***Fiery Teleport (Costs 2 Actions).*** Severin, along with any objects he is wearing or carrying, teleports up to 60 feet to an unoccupied space he can see. Each creature within 5 feet of Severin before he teleports takes 5 (1dlO) fire damage.
+***Fiery Teleport (Costs 2 Actions).*** Severin, along with any objects he is wearing or carrying, teleports up to 60 feet to an unoccupied space he can see. Each creature within 5 feet of Severin before he teleports takes 5 (1d10) fire damage.
 
 ***Hellish Chains (Costs 3 Actions).*** Severin targets one creature he can see within 30 feet of him. The target is wrapped in magical chains of fire and restrained. The restrained target takes 21 (6d6) fire damage at the start of each of its turns. At the end of its turns, the target can make a DC 17 Strength saving throw, ending the effect on itself on a success.
 


### PR DESCRIPTION
* duplicated Legendary Actions description, correct text was under Attack
* OCR issue on Fiery Teleport damage: 1dlO -> 1d10