### PR TITLE
Corrected hit points for several creatures

### DIFF
--- a/_posts/2017-09-10-beholder.markdown
+++ b/_posts/2017-09-10-beholder.markdown
@@ -9,7 +9,7 @@ tags: [large, aberration, cr13, monster-manual]
 
 **Armor Class** 18 (natural armor)
 
-**Hit Points** 189 (19d10+76)
+**Hit Points** 180 (19d10+76)
 
 **Speed** 0 ft., fly 20 ft. (hover)
 

--- a/_posts/2017-09-10-choldrith.markdown
+++ b/_posts/2017-09-10-choldrith.markdown
@@ -9,7 +9,7 @@ tags: [medium, monstrosity, cr3, volos-guide]
 
 **Armor Class** 15 (studded leather armor)
 
-**Hit Points** 15 (12d8+12)
+**Hit Points** 66 (12d8+12)
 
 **Speed** 30 ft., climb 30 ft.
 

--- a/_posts/2017-09-10-cloud-giant-smiling-one.markdown
+++ b/_posts/2017-09-10-cloud-giant-smiling-one.markdown
@@ -9,7 +9,7 @@ tags: [huge, giant, cr11, volos-guide]
 
 **Armor Class** 15 (natural armor)
 
-**Hit Points** 262 (21d12+128)
+**Hit Points** 262 (21d12+126)
 
 **Speed** 40 ft.
 

--- a/_posts/2017-09-10-demogorgon.markdown
+++ b/_posts/2017-09-10-demogorgon.markdown
@@ -9,7 +9,7 @@ tags: [huge, fiend, cr26, out-of-the-abyss]
 
 **Armor Class** 22 (natural armor)
 
-**Hit Points** 496 (34d12+272)
+**Hit Points** 493 (34d12+272)
 
 **Speed** 50 ft., swim 50 ft.
 

--- a/_posts/2017-09-10-dragon-turtle.markdown
+++ b/_posts/2017-09-10-dragon-turtle.markdown
@@ -9,7 +9,7 @@ tags: [gargantuan, dragon, cr17, monster-manual]
 
 **Armor Class** 20 (natural armor)
 
-**Hit Points** 341 (22d20+10)
+**Hit Points** 341 (22d20+110)
 
 **Speed** 20 ft., swim 40 ft.
 

--- a/_posts/2017-09-10-duergar-darkhaft.markdown
+++ b/_posts/2017-09-10-duergar-darkhaft.markdown
@@ -9,7 +9,7 @@ tags: [medium, humanoid, cr2, out-of-the-abyss]
 
 **Armor Class** 16 (scale mail, shield)
 
-**Hit Points** 26 (4d8+4)
+**Hit Points** 26 (4d8+8)
 
 **Speed** 25 ft.
 

--- a/_posts/2017-09-10-duergar-kavalrachni.markdown
+++ b/_posts/2017-09-10-duergar-kavalrachni.markdown
@@ -9,7 +9,7 @@ tags: [medium, humanoid, cr2, out-of-the-abyss]
 
 **Armor Class** 16 (scale mail, shield)
 
-**Hit Points** 26 (4d8+4)
+**Hit Points** 26 (4d8+8)
 
 **Speed** 25 ft.
 

--- a/_posts/2017-09-10-duergar-keeper-of-the-flame.markdown
+++ b/_posts/2017-09-10-duergar-keeper-of-the-flame.markdown
@@ -9,7 +9,7 @@ tags: [medium, humanoid, cr2, out-of-the-abyss]
 
 **Armor Class** 16 (scale mail, shield)
 
-**Hit Points** 26 (4d8+4)
+**Hit Points** 26 (4d8+8)
 
 **Speed** 25 ft.
 

--- a/_posts/2017-09-10-duergar.markdown
+++ b/_posts/2017-09-10-duergar.markdown
@@ -9,7 +9,7 @@ tags: [medium, humanoid, cr1, monster-manual]
 
 **Armor Class** 16 (scale mail, shield)
 
-**Hit Points** 26 (4d8+4)
+**Hit Points** 26 (4d8+8)
 
 **Speed** 25 ft.
 

--- a/_posts/2017-09-10-gar-shatterkeel.markdown
+++ b/_posts/2017-09-10-gar-shatterkeel.markdown
@@ -9,7 +9,7 @@ tags: [medium, humanoid, cr9, elemental-evil]
 
 **Armor Class** 16 (natural armor)
 
-**Hit Points** 30 (15d8+45)
+**Hit Points** 112 (15d8+45)
 
 **Speed** 30 ft., swim 30 ft.
 

--- a/_posts/2017-09-10-giant-boar.markdown
+++ b/_posts/2017-09-10-giant-boar.markdown
@@ -9,7 +9,7 @@ tags: [large, beast, cr2, monster-manual]
 
 **Armor Class** 12 (natural armor)
 
-**Hit Points** 42 (5d10+5)
+**Hit Points** 42 (5d10+15)
 
 **Speed** 40 ft.
 

--- a/_posts/2017-09-10-hook-horror-spore-servant.markdown
+++ b/_posts/2017-09-10-hook-horror-spore-servant.markdown
@@ -9,7 +9,7 @@ tags: [medium, plant, cr3, out-of-the-abyss]
 
 **Armor Class** 15 (natural armor)
 
-**Hit Points** 75 (10d10+10)
+**Hit Points** 75 (10d10+20)
 
 **Speed** 20 ft., climb 20 ft.
 

--- a/_posts/2017-09-10-master-thief.markdown
+++ b/_posts/2017-09-10-master-thief.markdown
@@ -9,7 +9,7 @@ tags: [medium, humanoid, cr5, volos-guide]
 
 **Armor Class** 16 (studded leather armor)
 
-**Hit Points** 83 (13d8+26)
+**Hit Points** 84 (13d8+26)
 
 **Speed** 30 ft.
 

--- a/_posts/2017-09-10-razerblast.markdown
+++ b/_posts/2017-09-10-razerblast.markdown
@@ -9,7 +9,7 @@ tags: [medium, humanoid, cr5, elemental-evil]
 
 **Armor Class** 17 (splint)
 
-**Hit Points** 112 (15d8+75)
+**Hit Points** 112 (15d8+45)
 
 **Speed** 30 ft.
 

--- a/_posts/2017-09-10-thurl-merosska.markdown
+++ b/_posts/2017-09-10-thurl-merosska.markdown
@@ -9,7 +9,7 @@ tags: [medium, humanoid, cr3, tyranny-of-dragons]
 
 **Armor Class** 16 (breastplate)
 
-**Hit Points** 71 (11d8+21)
+**Hit Points** 71 (11d8+22)
 
 **Speed** 30 ft.
 

--- a/_posts/2017-09-10-ulitharid.markdown
+++ b/_posts/2017-09-10-ulitharid.markdown
@@ -9,7 +9,7 @@ tags: [large, aberration, cr9, volos-guide]
 
 **Armor Class** 15 (breastplate)
 
-**Hit Points** 127 (17d10+14)
+**Hit Points** 127 (17d10+34)
 
 **Speed** 30 ft.
 

--- a/_posts/2017-09-10-vine-blight.markdown
+++ b/_posts/2017-09-10-vine-blight.markdown
@@ -9,7 +9,7 @@ tags: [medium, plant, cr1/2, monster-manual]
 
 **Armor Class** 12 (natural armor)
 
-**Hit Points** 26 (4d8+4)
+**Hit Points** 26 (4d8+8)
 
 **Speed** 10 ft.
 


### PR DESCRIPTION
The average hit points stat should always be = (n * (nrOfSidesOfDice + 1)/2) + (constitution modifier * n)

So if the hit points of a creature is 19d10 and the constitution modifier is +4 then the avg HP roll would be:
(19 * ((10+1)/2)) + (4 * 19) **=>** 19 * 5,5 + 76 **=** 180,5 **=>** 180

(and it's also always rounded down)

I've verified a few of the corrections against dndbeyond, where I could, and some I've intuited.
