### PR TITLE
correctly spelled target

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,25 +1,28 @@
----
-layout: default
+--- 
+layout: default 
 ---
 <div class="post">
 
-  <header class="post-header">
-    <h1 class="post-title">{{ page.title }}</h1>
-    <dl class="tag-list">
-    <dt>Tags:</dt>
-    {% for tag in page.tags %}
-    <dd>
-        {% if tag contains 'cr' %}
-          <a href="{{site.baseurl}}/#{{tag}}">{{tag}}</a>
-        {% else %}
-          <a href="{{site.baseurl}}/tags/{{tag}}.html">{{tag}}</a>
-        {% endif %}
-    </dd>
-    {% endfor %}
-  </header>
+    <header class="post-header">
+        <h1 class="post-title">{{ page.title }}</h1>
+        <dl class="tag-list">
+            <dt>Tags:</dt> {% for tag in page.tags %}
+            <dd>
+                {% if tag contains 'cr' %}
+                <a href="{{site.baseurl}}/#{{tag}}">{{tag}}</a> {% else %}
+                <a href="{{site.baseurl}}/tags/{{tag}}.html">{{tag}}</a> {% endif %}
+            </dd>
+            {% endfor %}
+            <dd>
+                {% if page.page_number %}
+                (p. {{ page.page_number }})
+                {% endif %}
+            </dd>
+        </dl>
+    </header>
 
-  <article class="post-content">
-    {{ content }}
-  </article>
+    <article class="post-content">
+        {{ content }}
+    </article>
 
 </div>

--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -4,42 +4,36 @@
 {% include head.html %}
 
 <body class="class-list">
-	{% include header.html %}
+    {% include header.html %}
 
-	<div class="page-content">
-		<div class="wrapper">
-			<h1 class="page-heading">{{page.title}}</h1>
-			<p id="creatureSearch">Search by name: <input type="search" id="jetsSearch"></p>
-			<dl class="tag-list">
-				<dt>Challenge Rating:</dt>
-				{% for level in site.data.levels %}
-				<dd>
-					<a href="#{{level.tag}}">{{level.name}}</a>
-				</dd>
-				{% endfor %}
-			</dl>
+    <div class="page-content">
+        <div class="wrapper">
+            <h1 class="page-heading">{{page.title}}</h1>
+            <p id="creatureSearch">Search by name: <input type="search" id="jetsSearch"></p>
+            <dl class="tag-list">
+                <dt>Challenge Rating:</dt> 
+                {% for level in site.data.levels %}
+                <dd>
+                    <a href="#{{level.tag}}">{{level.name}}</a>
+                </dd>
+                {% endfor %}
+            </dl>
 
-			{% for level in site.data.levels %}
-			<a id="{{level.tag}}"></a>
-			<h2 class="post-list-head jetsHide">{{level.title}}</h2>
-			{% assign post_list = site.tags.[{{level.tag}}] | sort: 'title' %}
-			{% for post in post_list %}
-			{% for tag in post.tags %}
-			{% if tag == page.tag %}
-			<ul class="post-list jetsContent">
-				<li>
-					<a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-				</li>
-			</ul>
-			{% endif %}
-			{% endfor %}
-			{% endfor %}
-			<a class="post-meta jetsHide" href="#top">Back to top &#8593;</a>
-			{% endfor %}
-		</div>
-	</div>
+            {% for level in site.data.levels %}
+            <a id="{{level.tag}}"></a>
+            <h2 class="post-list-head jetsHide">{{level.title}}</h2>
+            {% assign post_list = site.tags.[{{level.tag}}] | sort: 'title' %} {% for post in post_list %} {% for tag in post.tags %} {% if tag == page.tag %}
+            <ul class="post-list jetsContent">
+                <li>
+                    <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+                </li>
+            </ul>
+            {% endif %} {% endfor %} {% endfor %}
+            <a class="post-meta jetsHide" href="#top">Back to top &#8593;</a> {% endfor %}
+        </div>
+    </div>
 
-	{% include footer.html %}
+    {% include footer.html %}
 
 </body>
 

--- a/_posts/2017-09-10-baba-lysaga.markdown
+++ b/_posts/2017-09-10-baba-lysaga.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Baba Lysaga"
 date: 2017-09-10
 tags: [medium, humanoid, cr11, curse-of-strahd]
+page_number: 228
 ---
 
 **Medium humanoid (human, shapechanger), chaotic evil**

--- a/_posts/2017-09-10-baba-lysagas-creeping-hut.markdown
+++ b/_posts/2017-09-10-baba-lysagas-creeping-hut.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Baba Lysaga's Creeping Hut"
 date: 2017-09-10
 tags: [gargantuan, construct, cr11, curse-of-strahd]
+page_number: 226
 ---
 
 **Gargantuan construct, unaligned**

--- a/_posts/2017-09-10-barovian-witch.markdown
+++ b/_posts/2017-09-10-barovian-witch.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Barovian Witch"
 date: 2017-09-10
 tags: [medium, humanoid, cr1/2, curse-of-strahd]
+page_number: 229
 ---
 
 **Medium humanoid (human), chaotic evil**

--- a/_posts/2017-09-10-broom-of-animated-attack.markdown
+++ b/_posts/2017-09-10-broom-of-animated-attack.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Broom of Animated Attack"
 date: 2017-09-10
 tags: [small, construct, cr1/4, curse-of-strahd]
+page_number: 226
 ---
 
 **Small construct, unaligned**

--- a/_posts/2017-09-10-crag-cat.markdown
+++ b/_posts/2017-09-10-crag-cat.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Crag Cat"
 date: 2017-09-10
 tags: [large, beast, cr1, storm-kings-thunder]
+page_number: 17
 ---
 
 **Large beast, unaligned**

--- a/_posts/2017-09-10-crag-cat.markdown
+++ b/_posts/2017-09-10-crag-cat.markdown
@@ -29,7 +29,7 @@ tags: [large, beast, cr1, storm-kings-thunder]
 
 ***Pounce.*** If the cat moves at least 20 feet straight toward a creature then hits it with a claw attack on the same turn, that target must succeed on a DC13 Strength saving throw or be knocked prone.  If the target is prone, the cat can make one bite attack against it as a bonus action.
 
-***Spell Turning.*** The cat has advantage on saving throws against any spell that tagets only the cat (not an area). If the cat's saving throw succeeds and the spell is of 7th level or lower, the spell has no effect on the cat and instead tagets the caster.
+***Spell Turning.*** The cat has advantage on saving throws against any spell that targets only the cat (not an area). If the cat's saving throw succeeds and the spell is of 7th level or lower, the spell has no effect on the cat and instead targets the caster.
 
 **Actions**
 

--- a/_posts/2017-09-10-ezmerelda-davenir.markdown
+++ b/_posts/2017-09-10-ezmerelda-davenir.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Ezmerelda d'Avenir"
 date: 2017-09-10
 tags: [medium, humanoid, cr8, curse-of-strahd]
+page_number: 230
 ---
 
 **Medium humanoid (human), chaotic good**

--- a/_posts/2017-09-10-guardian-portrait.markdown
+++ b/_posts/2017-09-10-guardian-portrait.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Guardian Portrait"
 date: 2017-09-10
 tags: [medium, construct, cr1, curse-of-strahd]
+page_number: 227
 ---
 
 **Medium construct, unaligned**

--- a/_posts/2017-09-10-izek-strazni.markdown
+++ b/_posts/2017-09-10-izek-strazni.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Izek Strazni"
 date: 2017-09-10
 tags: [medium, humanoid, cr5, curse-of-strahd]
+page_number: 231
 ---
 
 **Medium humanoid (human), neutral evil**

--- a/_posts/2017-09-10-madam-eva.markdown
+++ b/_posts/2017-09-10-madam-eva.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Madam Eva"
 date: 2017-09-10
 tags: [medium, humanoid, cr10, curse-of-strahd]
+page_number: 233
 ---
 
 **Medium humanoid (human), chaotic neutral**

--- a/_posts/2017-09-10-mongrelfolk.markdown
+++ b/_posts/2017-09-10-mongrelfolk.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Mongrelfolk"
 date: 2017-09-10
 tags: [medium, humanoid, cr1/4, curse-of-strahd]
+page_number: 234
 ---
 
 **Medium humanoid (mongrelfolk), any alignment**

--- a/_posts/2017-09-10-phantom-warrior.markdown
+++ b/_posts/2017-09-10-phantom-warrior.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Phantom Warrior"
 date: 2017-09-10
 tags: [medium, undead, cr1, curse-of-strahd]
+page_number: 235
 ---
 
 **Medium undead, any alignment**

--- a/_posts/2017-09-10-pidlwick-ii.markdown
+++ b/_posts/2017-09-10-pidlwick-ii.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Pidlwick II"
 date: 2017-09-10
 tags: [small, construct, cr1/4, curse-of-strahd]
+page_number: 235
 ---
 
 **Small construct, neutral evil**

--- a/_posts/2017-09-10-rahadin.markdown
+++ b/_posts/2017-09-10-rahadin.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Rahadin"
 date: 2017-09-10
 tags: [medium, humanoid, cr10, curse-of-strahd]
+page_number: 236
 ---
 
 **Medium humanoid (elf), lawful evil**

--- a/_posts/2017-09-10-rictavio.markdown
+++ b/_posts/2017-09-10-rictavio.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Rictavio"
 date: 2017-09-10
 tags: [medium, humanoid, cr5, curse-of-strahd]
+page_number: 238
 ---
 
 **Medium humanoid (human), lawful good**

--- a/_posts/2017-09-10-strahd-von-zarovich.markdown
+++ b/_posts/2017-09-10-strahd-von-zarovich.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Strahd von Zarovich"
 date: 2017-09-10
 tags: [medium, undead, cr15, curse-of-strahd]
+page_number: 239
 ---
 
 **Medium undead (shapechanger), lawful evil**

--- a/_posts/2017-09-10-strahd-zombie.markdown
+++ b/_posts/2017-09-10-strahd-zombie.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Strahd Zombie"
 date: 2017-09-10
 tags: [medium, undead, cr1, curse-of-strahd]
+page_number: 241
 ---
 
 **Medium undead, unaligned**

--- a/_posts/2017-09-10-strahds-animated-armor.markdown
+++ b/_posts/2017-09-10-strahds-animated-armor.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Strahd's Animated Armor"
 date: 2017-09-10
 tags: [medium, construct, cr6, curse-of-strahd]
+page_number: 227
 ---
 
 **Medium construct, lawful evil**

--- a/_posts/2017-09-10-tree-blight.markdown
+++ b/_posts/2017-09-10-tree-blight.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Tree Blight"
 date: 2017-09-10
 tags: [huge, plant, cr7, curse-of-strahd]
+page_number: 230
 ---
 
 **Huge plant, neutral evil**

--- a/_posts/2017-09-10-vladimir-horngaard.markdown
+++ b/_posts/2017-09-10-vladimir-horngaard.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Vladimir Horngaard"
 date: 2017-09-10
 tags: [medium, undead, cr7, curse-of-strahd]
+page_number: 241
 ---
 
 **Medium undead, lawful evil**

--- a/_posts/2017-09-10-wereraven.markdown
+++ b/_posts/2017-09-10-wereraven.markdown
@@ -3,6 +3,7 @@ layout: post
 title: "Wereraven"
 date: 2017-09-10
 tags: [medium, humanoid, cr2, curse-of-strahd]
+page_number: 242
 ---
 
 **Medium humanoid (human, shapechanger), lawful good**


### PR DESCRIPTION
Noticed that "target" had been spelled "taget" twice on the _Crag Cat_ page, so I just changed it to target. Also searched the repo for any more instances of this particular spelling with no success, which is good I guess. Okay!