### PR TITLE
Update stench-kow.md

### DIFF
--- a/_creatures/stench-kow.md
+++ b/_creatures/stench-kow.md
@@ -21,7 +21,7 @@ armor_class: "10"
 
 ***Charge.*** If the kow moves at least 20 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 7 (2d6) piercing damage.
 
-***Stench.*** Any creature other than a stench kow that starts its turn within 5 feet of the stench kow must succeed on a DC 26 Constitution saving throw or be poisoned until the start of the creature's next turn. On a successful saving throw, the creature is immune to the stench of all stench kows for 1 hour.
+***Stench.*** Any creature other than a stench kow that starts its turn within 5 feet of the stench kow must succeed on a DC 12 Constitution saving throw or be poisoned until the start of the creature's next turn. On a successful saving throw, the creature is immune to the stench of all stench kows for 1 hour.
 
 ### Actions
 


### PR DESCRIPTION
Save DC was 26, but Volo's has it as 12 (which makes a lot more sense for a CR 1/4 creature).